### PR TITLE
Implement peer registry for DirectoryService

### DIFF
--- a/src/DirectoryService/DirectoryService.csproj
+++ b/src/DirectoryService/DirectoryService.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AddressableHealthSystems.ServiceDefaults\AddressableHealthSystems.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/DirectoryService/Endpoints/PeerRegistryEndpoints.cs
+++ b/src/DirectoryService/Endpoints/PeerRegistryEndpoints.cs
@@ -1,0 +1,30 @@
+using DirectoryService.Services;
+using Shared;
+
+namespace DirectoryService.Endpoints;
+
+public static class PeerRegistryEndpoints
+{
+    public static IEndpointRouteBuilder MapPeerRegistryEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/peers", async (IPeerRegistryService registry, CancellationToken ct) =>
+        {
+            var peers = await registry.GetPeersAsync(ct).ConfigureAwait(false);
+            return Results.Ok(peers);
+        });
+
+        endpoints.MapGet("/peers/{id}", async (string id, IPeerRegistryService registry, CancellationToken ct) =>
+        {
+            var peer = await registry.GetPeerAsync(id, ct).ConfigureAwait(false);
+            return peer is null ? Results.NotFound() : Results.Ok(peer);
+        });
+
+        endpoints.MapPost("/peers", async (PeerInfo peer, IPeerRegistryService registry, CancellationToken ct) =>
+        {
+            await registry.AddOrUpdatePeerAsync(peer, ct).ConfigureAwait(false);
+            return Results.Ok();
+        });
+
+        return endpoints;
+    }
+}

--- a/src/DirectoryService/Program.cs
+++ b/src/DirectoryService/Program.cs
@@ -1,3 +1,5 @@
+using DirectoryService.Endpoints;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
@@ -5,10 +7,12 @@ builder.AddServiceDefaults();
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddSingleton<DirectoryService.Services.IPeerRegistryService, DirectoryService.Services.PeerRegistryService>();
 
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
+app.MapPeerRegistryEndpoints();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/DirectoryService/Services/PeerRegistryService.cs
+++ b/src/DirectoryService/Services/PeerRegistryService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using Shared;
+
+namespace DirectoryService.Services;
+
+public interface IPeerRegistryService
+{
+    Task<IReadOnlyList<PeerInfo>> GetPeersAsync(CancellationToken ct = default);
+    Task AddOrUpdatePeerAsync(PeerInfo peer, CancellationToken ct = default);
+    Task<PeerInfo?> GetPeerAsync(string id, CancellationToken ct = default);
+}
+
+public class PeerRegistryService : IPeerRegistryService
+{
+    private readonly ConcurrentDictionary<string, PeerInfo> _peers = new();
+
+    public Task<IReadOnlyList<PeerInfo>> GetPeersAsync(CancellationToken ct = default)
+    {
+        IReadOnlyList<PeerInfo> list = _peers.Values.ToList();
+        return Task.FromResult(list);
+    }
+
+    public Task AddOrUpdatePeerAsync(PeerInfo peer, CancellationToken ct = default)
+    {
+        _peers[peer.Id] = peer;
+        return Task.CompletedTask;
+    }
+
+    public Task<PeerInfo?> GetPeerAsync(string id, CancellationToken ct = default)
+    {
+        _peers.TryGetValue(id, out var peer);
+        return Task.FromResult(peer);
+    }
+}

--- a/src/Shared/PeerInfo.cs
+++ b/src/Shared/PeerInfo.cs
@@ -1,0 +1,3 @@
+namespace Shared;
+
+public record PeerInfo(string Id, string BaseUrl, string MessagingEndpoint, bool IsTrusted);


### PR DESCRIPTION
## Summary
- add `PeerInfo` record in Shared project
- implement `PeerRegistryService` to keep a simple in-memory peer registry
- expose `/peers` and `/peers/{id}` endpoints from DirectoryService
- wire up service and endpoints in the DirectoryService app
- reference Shared project from DirectoryService

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*