### PR TITLE
Add direct delivery mode and unit tests

### DIFF
--- a/src/MessagingService/Endpoints/CommunicationEndpoints.cs
+++ b/src/MessagingService/Endpoints/CommunicationEndpoints.cs
@@ -1,5 +1,6 @@
 using Hl7.Fhir.Model;
 using MessagingService.Handlers;
+using Shared;
 
 namespace MessagingService.Endpoints;
 
@@ -34,7 +35,7 @@ public static class CommunicationEndpoints
         {
             var cancellationToken = context.RequestAborted;
             return await handler
-                .HandleIncomingCommunicationAsync(context, communication, cancellationToken)
+                .HandleIncomingCommunicationAsync(context, communication, DeliveryMode.StoreAndForward, cancellationToken)
                 .ConfigureAwait(false);
         })
         .WithName("PostCommunication")

--- a/src/MessagingService/MessagingService.csproj
+++ b/src/MessagingService/MessagingService.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <ProjectReference Include="..\AddressableHealthSystems.ServiceDefaults\AddressableHealthSystems.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\DirectoryService\DirectoryService.csproj" />
+    <ProjectReference Include="..\PeerMessagingService\PeerMessagingService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MessagingService/Program.cs
+++ b/src/MessagingService/Program.cs
@@ -1,7 +1,9 @@
 using MessagingService.Endpoints;
 using MessagingService.Handlers;
 using MessagingService.Services;
-using Hl7.Fhir.Rest; 
+using DirectoryService.Services;
+using PeerMessagingService.Services;
+using Hl7.Fhir.Rest;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,6 +20,8 @@ builder.Services.AddSingleton<IFhirStorageService, FhirStorageService>();
 builder.Services.AddSingleton<IFhirClientAdapter, FhirClientAdapter>();
 builder.Services.AddSingleton<IAuditService, AuditService>();
 builder.Services.AddTransient<ICommunicationHandler, CommunicationHandler>();
+builder.Services.AddSingleton<IPeerRegistryService, PeerRegistryService>();
+builder.Services.AddScoped<PeerMessenger>();
 
 // --- Auth ---
 builder.Services.AddAuthorization(options =>

--- a/src/Shared/DeliveryMode.cs
+++ b/src/Shared/DeliveryMode.cs
@@ -1,0 +1,7 @@
+namespace Shared;
+
+public enum DeliveryMode
+{
+    StoreAndForward,
+    Direct
+}

--- a/tests/MessagingService.Tests/CommunicationHandlerTests.cs
+++ b/tests/MessagingService.Tests/CommunicationHandlerTests.cs
@@ -51,7 +51,7 @@ public class CommunicationHandlerTests
 
 
         // Act
-        var result = await handler.HandleIncomingCommunicationAsync(context, communication, CancellationToken.None);
+        var result = await handler.HandleIncomingCommunicationAsync(context, communication, DeliveryMode.StoreAndForward, CancellationToken.None);
 
         // Assert
         var okResult = Assert.IsType<Ok<string>>(result.Result);
@@ -81,7 +81,7 @@ public class CommunicationHandlerTests
                  .ReturnsAsync(AuthorizationResult.Failed());
 
         // Act
-        var result = await handler.HandleIncomingCommunicationAsync(context, new Communication(), CancellationToken.None);
+        var result = await handler.HandleIncomingCommunicationAsync(context, new Communication(), DeliveryMode.StoreAndForward, CancellationToken.None);
 
         // Assert
         Assert.IsType<ForbidHttpResult>(result.Result);
@@ -102,7 +102,7 @@ public class CommunicationHandlerTests
                         .ReturnsAsync((false, null));
 
         // Act
-        var result = await handler.HandleIncomingCommunicationAsync(context, communication, CancellationToken.None);
+        var result = await handler.HandleIncomingCommunicationAsync(context, communication, DeliveryMode.StoreAndForward, CancellationToken.None);
 
         // Assert
         Assert.IsType<ProblemHttpResult>(result.Result);
@@ -173,6 +173,77 @@ public class CommunicationHandlerTests
         factory.AuditServiceMock.Verify(a =>
             a.RecordAuditAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
             Times.Never); // No audit if not found
+    }
+
+    [Fact]
+    public async Task HandleIncomingCommunicationAsync_SendsDirect_WhenModeDirect()
+    {
+        var handler = factory.Create();
+        var context = CreateHttpContext();
+        var communication = new Communication
+        {
+            Id = "comm-direct",
+            Recipient = [ new ResourceReference("peer-1") ],
+            Status = EventStatus.Completed
+        };
+
+        factory.AuthorizationServiceMock.Setup(x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object?>(), "CanPostCommunication"))
+            .ReturnsAsync(AuthorizationResult.Success());
+
+        var peer = new PeerInfo("peer-1", "http://p", "http://p/msg", true);
+        factory.PeerRegistryMock.Setup(x => x.GetPeerAsync("peer-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(peer);
+        factory.PeerMessengerMock.Setup(x => x.SendCommunicationAsync(peer, communication, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await handler.HandleIncomingCommunicationAsync(context, communication, DeliveryMode.Direct, CancellationToken.None);
+
+        Assert.IsType<Ok<string>>(result.Result);
+        factory.PeerMessengerMock.Verify(x => x.SendCommunicationAsync(peer, communication, It.IsAny<CancellationToken>()), Times.Once);
+        factory.FhirStorageMock.Verify(x => x.StoreResourceAsync(It.IsAny<Communication>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleIncomingCommunicationAsync_FallsBack_WhenDirectFails()
+    {
+        var handler = factory.Create();
+        var context = CreateHttpContext();
+        var communication = new Communication
+        {
+            Id = "comm-fallback",
+            Recipient = [ new ResourceReference("peer-1") ],
+            Status = EventStatus.Completed
+        };
+
+        factory.AuthorizationServiceMock.Setup(x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object?>(), "CanPostCommunication"))
+            .ReturnsAsync(AuthorizationResult.Success());
+
+        var peer = new PeerInfo("peer-1", "http://p", "http://p/msg", true);
+        factory.PeerRegistryMock.Setup(x => x.GetPeerAsync("peer-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(peer);
+        factory.PeerMessengerMock.Setup(x => x.SendCommunicationAsync(peer, communication, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        factory.FhirStorageMock.Setup(x => x.StoreResourceAsync(communication, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, "fhir-1"));
+        factory.DaprClientMock.Setup(d => d.PublishEventAsync(
+                "pubsub",
+                "messaging-delivery",
+                It.IsAny<CommunicationDeliveryEvent>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await handler.HandleIncomingCommunicationAsync(context, communication, DeliveryMode.Direct, CancellationToken.None);
+
+        Assert.IsType<Ok<string>>(result.Result);
+        factory.PeerMessengerMock.Verify(x => x.SendCommunicationAsync(peer, communication, It.IsAny<CancellationToken>()), Times.Once);
+        factory.FhirStorageMock.Verify(x => x.StoreResourceAsync(communication, It.IsAny<CancellationToken>()), Times.Once);
+        factory.DaprClientMock.Verify(d => d.PublishEventAsync(
+                "pubsub",
+                "messaging-delivery",
+                It.IsAny<CommunicationDeliveryEvent>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
 }

--- a/tests/MessagingService.Tests/MessagingService.Tests.csproj
+++ b/tests/MessagingService.Tests/MessagingService.Tests.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MessagingService\MessagingService.csproj" />
+    <ProjectReference Include="..\..\src\DirectoryService\DirectoryService.csproj" />
+    <ProjectReference Include="..\..\src\PeerMessagingService\PeerMessagingService.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MessagingService.Tests/TestHandlerFactory.cs
+++ b/tests/MessagingService.Tests/TestHandlerFactory.cs
@@ -1,6 +1,9 @@
 using Dapr.Client;
 using MessagingService.Handlers;
 using MessagingService.Services;
+using DirectoryService.Services;
+using PeerMessagingService.Services;
+using System.Net.Http;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -13,6 +16,8 @@ public class TestHandlerFactory
     public Mock<IAuditService> AuditServiceMock { get; } = new();
     public Mock<IAuthorizationService> AuthorizationServiceMock { get; } = new();
     public Mock<DaprClient> DaprClientMock { get; } = new();
+    public Mock<IPeerRegistryService> PeerRegistryMock { get; } = new();
+    public Mock<PeerMessenger> PeerMessengerMock { get; } = new(new HttpClient());
     public ILogger<CommunicationHandler> Logger { get; } = Mock.Of<ILogger<CommunicationHandler>>();
 
     public CommunicationHandler Create()
@@ -22,7 +27,9 @@ public class TestHandlerFactory
             Logger,
             AuditServiceMock.Object,
             AuthorizationServiceMock.Object,
-            DaprClientMock.Object
+            DaprClientMock.Object,
+            PeerRegistryMock.Object,
+            PeerMessengerMock.Object
         );
     }
 }


### PR DESCRIPTION
## Summary
- support a new `DeliveryMode` enum
- extend `CommunicationHandler` for direct mode using `PeerRegistryService` and `PeerMessenger`
- register new services in MessagingService
- update existing tests and add scenarios for direct delivery

## Testing
- `dotnet test` *(fails: `dotnet` not found)*