### PR TITLE
Add direct messaging mode

### DIFF
--- a/src/MessagingService/MessagingOptions.cs
+++ b/src/MessagingService/MessagingOptions.cs
@@ -1,0 +1,12 @@
+namespace MessagingService;
+
+public enum MessagingDeliveryMode
+{
+    StoreAndForward,
+    Direct
+}
+
+public class MessagingOptions
+{
+    public MessagingDeliveryMode DeliveryMode { get; set; } = MessagingDeliveryMode.StoreAndForward;
+}

--- a/src/MessagingService/MessagingService.csproj
+++ b/src/MessagingService/MessagingService.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <ProjectReference Include="..\AddressableHealthSystems.ServiceDefaults\AddressableHealthSystems.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\DirectoryService\DirectoryService.csproj" />
+    <ProjectReference Include="..\PeerMessagingService\PeerMessagingService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MessagingService/Program.cs
+++ b/src/MessagingService/Program.cs
@@ -1,6 +1,8 @@
 using MessagingService.Endpoints;
 using MessagingService.Handlers;
 using MessagingService.Services;
+using DirectoryService.Services;
+using PeerMessagingService.Services;
 using Hl7.Fhir.Rest; 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +10,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
 builder.Services.AddDaprClient();
+builder.Services.Configure<MessagingOptions>(builder.Configuration.GetSection("Messaging"));
+builder.Services.AddHttpClient<PeerMessenger>("peermessagingservice");
+builder.Services.AddHttpClient<IPeerRegistryService, PeerRegistryClient>("directoryservice");
 
 
 // If switching to Firely FhirClient SDK, use this instead:

--- a/src/MessagingService/Services/PeerRegistryClient.cs
+++ b/src/MessagingService/Services/PeerRegistryClient.cs
@@ -1,0 +1,28 @@
+using System.Net.Http.Json;
+using DirectoryService.Services;
+using Shared;
+
+namespace MessagingService.Services;
+
+public class PeerRegistryClient(HttpClient httpClient) : IPeerRegistryService
+{
+    public async Task<IReadOnlyList<PeerInfo>> GetPeersAsync(CancellationToken ct = default)
+    {
+        var peers = await httpClient.GetFromJsonAsync<IReadOnlyList<PeerInfo>>("/peers", ct).ConfigureAwait(false);
+        return peers ?? [];
+    }
+
+    public async Task AddOrUpdatePeerAsync(PeerInfo peer, CancellationToken ct = default)
+    {
+        await httpClient.PostAsJsonAsync("/peers", peer, ct).ConfigureAwait(false);
+    }
+
+    public async Task<PeerInfo?> GetPeerAsync(string id, CancellationToken ct = default)
+    {
+        var response = await httpClient.GetAsync($"/peers/{id}", ct).ConfigureAwait(false);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return null;
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<PeerInfo>(cancellationToken: ct).ConfigureAwait(false);
+    }
+}

--- a/src/MessagingService/appsettings.Development.json
+++ b/src/MessagingService/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Messaging": {
+    "DeliveryMode": "StoreAndForward"
   }
 }

--- a/src/MessagingService/appsettings.json
+++ b/src/MessagingService/appsettings.json
@@ -6,4 +6,7 @@
     }
   },
   "AllowedHosts": "*"
+  ,"Messaging": {
+    "DeliveryMode": "StoreAndForward"
+  }
 }

--- a/tests/MessagingService.Tests/TestHandlerFactory.cs
+++ b/tests/MessagingService.Tests/TestHandlerFactory.cs
@@ -3,6 +3,9 @@ using MessagingService.Handlers;
 using MessagingService.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using PeerMessagingService.Services;
+using DirectoryService.Services;
 using Moq;
 
 namespace MessagingService.Tests;
@@ -13,6 +16,9 @@ public class TestHandlerFactory
     public Mock<IAuditService> AuditServiceMock { get; } = new();
     public Mock<IAuthorizationService> AuthorizationServiceMock { get; } = new();
     public Mock<DaprClient> DaprClientMock { get; } = new();
+    public Mock<PeerMessenger> PeerMessengerMock { get; } = new(new HttpClient());
+    public Mock<IPeerRegistryService> PeerRegistryMock { get; } = new();
+    public IOptions<MessagingOptions> Options { get; set; } = Options.Create(new MessagingOptions());
     public ILogger<CommunicationHandler> Logger { get; } = Mock.Of<ILogger<CommunicationHandler>>();
 
     public CommunicationHandler Create()
@@ -22,7 +28,10 @@ public class TestHandlerFactory
             Logger,
             AuditServiceMock.Object,
             AuthorizationServiceMock.Object,
-            DaprClientMock.Object
+            DaprClientMock.Object,
+            Options,
+            PeerMessengerMock.Object,
+            PeerRegistryMock.Object
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `MessagingOptions` with `MessagingDeliveryMode`
- allow `CommunicationHandler` to directly deliver messages
- inject PeerMessenger and PeerRegistry client in MessagingService
- register HTTP clients and options in Program
- update tests for new dependencies and add direct mode test

## Testing
- `dotnet test` *(fails: command not found)*