### PR TITLE
Implement SyncToDirectory

### DIFF
--- a/docs/client/admin/discovery.md
+++ b/docs/client/admin/discovery.md
@@ -24,6 +24,7 @@ The Discovery page allows administrators to initiate and manage AHS-to-AHS disco
   - Name, Version, Role, Trust Status
 - **Sync to Directory** button (if compatible)
   - Imports `Organization`, `Endpoint`, and other supported resources
+  - Posts the peer information to the local **DirectoryService** (`/peers`)
 
 ## 🧱 UI Components
 

--- a/src/Client/docs/admin/discovery.md
+++ b/src/Client/docs/admin/discovery.md
@@ -29,7 +29,7 @@ The Discovery page allows you to connect with other AHS instances by entering th
 2. Enter the **remote FHIR base URL**
 3. Click **Discover**
 4. Review the remote instance's metadata
-5. Click **Sync to Directory** if it's a trusted system
+5. Click **Sync to Directory** if it's a trusted system. This posts the peer details to the local **DirectoryService**.
 
 ---
 

--- a/tests/Client.Tests/DiscoveryTests.cs
+++ b/tests/Client.Tests/DiscoveryTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Client.Components.Features.Admin;
+using Moq;
+using Moq.Protected;
+
+namespace Client.Tests;
+
+public class DiscoveryTests
+{
+    private class TestDiscovery : Discovery
+    {
+        public void SetClient(HttpClient client) => HttpClient = client;
+        public DiscoveryRequest Request => discoveryRequest;
+        public void SetResult(DiscoveryResult result) => discoveryResult = result;
+        public Task InvokeSync() => SyncToDirectory();
+    }
+
+    [Fact]
+    public async Task SyncToDirectory_PostsPeerInfo()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Post && r.RequestUri!.ToString() == "http://localhost:5131/peers"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var client = new HttpClient(handler.Object);
+        var comp = new TestDiscovery();
+        comp.SetClient(client);
+        comp.Request.EndpointUrl = "https://remote";
+        comp.SetResult(new Discovery.DiscoveryResult
+        {
+            RemoteName = "peer1",
+            IsTrusted = true,
+            Role = "hub",
+            SoftwareName = "AHS",
+            Version = "1.0",
+            IsAhsCompatible = true
+        });
+
+        await comp.InvokeSync();
+
+        handler.Protected().Verify("SendAsync", Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post && req.RequestUri!.ToString() == "http://localhost:5131/peers"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SyncToDirectory` to post discovered peers to DirectoryService
- expose HttpClient via DI for testing
- document that syncing posts to `/peers`
- add unit test covering the HTTP call

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683add818218832e9cfc9339192392da