### PR TITLE
Implement SettingsService persistence

### DIFF
--- a/src/Client/Components/Pages/Settings.razor.cs
+++ b/src/Client/Components/Pages/Settings.razor.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Components;
+using Client.Services;
 
 namespace Client.Components.Pages;
 
 public partial class Settings : ComponentBase
 {
+    [Inject] public ISettingsService SettingsService { get; set; } = default!;
     protected UserProfile profile = new();
     protected UserPreferences preferences = new();
 
@@ -24,11 +26,20 @@ public partial class Settings : ComponentBase
         };
     }
 
-    protected Task Save()
+    protected async Task Save()
     {
         Console.WriteLine($"[Save] {profile.DisplayName}, email alerts: {preferences.ReceiveEmailAlerts}");
-        // TODO: call SettingsService
-        return Task.CompletedTask;
+
+        var settings = new UserSettings
+        {
+            DisplayName = profile.DisplayName,
+            Email = profile.Email,
+            Role = profile.Role,
+            ReceiveEmailAlerts = preferences.ReceiveEmailAlerts,
+            ShowRealTimeToasts = preferences.ShowRealTimeToasts
+        };
+
+        await SettingsService.SaveAsync(settings);
     }
 
     public class UserProfile
@@ -44,3 +55,4 @@ public partial class Settings : ComponentBase
         public bool ShowRealTimeToasts { get; set; }
     }
 }
+

--- a/src/Client/Program.cs
+++ b/src/Client/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddRazorComponents()
 builder.Services.AddRadzenComponents();
 
 builder.Services.AddSingleton<IDocumentationService, FileDocumentationService>();
+builder.Services.AddSingleton<ISettingsService, FileSettingsService>();
 
 builder.Services.AddSingleton(new FhirClient("https://localhost:5172"));
 builder.Services.AddSingleton<IFhirOrganizationClient, FhirOrganizationClient>();

--- a/src/Client/Services/SettingsService.cs
+++ b/src/Client/Services/SettingsService.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Client.Services;
+
+public interface ISettingsService
+{
+    Task<UserSettings> GetAsync(CancellationToken ct = default);
+    Task SaveAsync(UserSettings settings, CancellationToken ct = default);
+}
+
+public class FileSettingsService : ISettingsService
+{
+    private readonly string _filePath;
+
+    public FileSettingsService(IWebHostEnvironment env)
+        : this(Path.Combine(env.ContentRootPath, "user-settings.json"))
+    {
+    }
+
+    // For tests
+    public FileSettingsService(string filePath)
+    {
+        _filePath = filePath;
+    }
+
+    public async Task<UserSettings> GetAsync(CancellationToken ct = default)
+    {
+        if (!File.Exists(_filePath))
+        {
+            return new UserSettings
+            {
+                DisplayName = "Dr. Taylor Jenkins",
+                Email = "tjenkins@greenfield.org",
+                Role = "Practitioner",
+                ReceiveEmailAlerts = true,
+                ShowRealTimeToasts = true
+            };
+        }
+
+        var json = await File.ReadAllTextAsync(_filePath, ct).ConfigureAwait(false);
+        return JsonSerializer.Deserialize<UserSettings>(json) ?? new UserSettings();
+    }
+
+    public async Task SaveAsync(UserSettings settings, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(_filePath, json, ct).ConfigureAwait(false);
+    }
+}
+
+public class UserSettings
+{
+    public string DisplayName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool ReceiveEmailAlerts { get; set; }
+    public bool ShowRealTimeToasts { get; set; }
+}
+

--- a/tests/Client.Tests/SettingsServiceTests.cs
+++ b/tests/Client.Tests/SettingsServiceTests.cs
@@ -1,0 +1,40 @@
+using Client.Services;
+
+namespace Client.Tests;
+
+public class SettingsServiceTests
+{
+    [Fact]
+    public async Task SaveAsync_PersistsSettings()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var service = new FileSettingsService(tempFile);
+            var settings = new UserSettings
+            {
+                DisplayName = "Test User",
+                Email = "test@example.com",
+                Role = "Practitioner",
+                ReceiveEmailAlerts = true,
+                ShowRealTimeToasts = false
+            };
+
+            await service.SaveAsync(settings);
+
+            var service2 = new FileSettingsService(tempFile);
+            var loaded = await service2.GetAsync();
+
+            Assert.Equal(settings.DisplayName, loaded.DisplayName);
+            Assert.Equal(settings.Email, loaded.Email);
+            Assert.Equal(settings.Role, loaded.Role);
+            Assert.Equal(settings.ReceiveEmailAlerts, loaded.ReceiveEmailAlerts);
+            Assert.Equal(settings.ShowRealTimeToasts, loaded.ShowRealTimeToasts);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a file-based `SettingsService`
- inject the service into Program and Settings page
- persist user settings when saving the Settings page
- add unit test verifying service persistence

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b7cf1b6f0832ea314f14a74036ad6